### PR TITLE
Add in methods for adding and removing flapper digits on the fly

### DIFF
--- a/src/jquery.flapper.js
+++ b/src/jquery.flapper.js
@@ -1,5 +1,7 @@
 (function($) {
 
+    var prependToId = 'Flap', flappers = {};
+
     var Flapper = function($ele, options) {
         var _this = this;
         this.id = Math.floor(Math.random() * 1000) + 1;
@@ -16,6 +18,10 @@
         this.$ele.bind('change.flapper', function(){
             _this.update();
         });
+        
+        var flapperId = this.$ele[0].id || prependToId + this.id;
+        this.$ele.attr('id', flapperId);
+        flappers[flapperId] = this;
         
         this.init();
     }
@@ -107,6 +113,33 @@
             }
 
             return digits;
+        },
+        
+        addDigit: function(){
+            var flapDigit = new FlapDigit(null, this.options);
+            if (this.options.align === 'left') {
+                this.digits.push(flapDigit);
+                this.$div.append(flapDigit.$ele);
+            }
+            else{
+                this.digits.unshift(flapDigit);
+                this.$div.prepend(flapDigit.$ele);
+            }
+            this.options.width = this.digits.length;
+            return flapDigit;
+        },
+        
+        removeDigit: function(){
+            var flapDigit = (this.options.align === 'left') ? this.digits.pop() : this.digits.shift();
+            flapDigit.$ele.remove();
+            this.options.width = this.digits.length;
+        },
+        
+        performAction: function(action){
+            switch(action){
+                case 'add-digit': this.addDigit(); break;
+                case 'remove-digit': this.removeDigit(); break;
+            }
         }
     }
 
@@ -253,9 +286,13 @@
         }
     };
 
-	$.fn.flapper = function(options) {
+    $.fn.flapper = function(arg) {
         this.each(function(){
-            new Flapper($(this), options);
+            if(!(typeof arg === 'string' || arg instanceof String)) return new Flapper($(this), arg);
+            
+            if(this.id && flappers.hasOwnProperty(this.id)){
+                flappers[this.id].performAction(arg);
+            }
         });
 
         return this;


### PR DESCRIPTION
@jayKayEss - I found myself needing to add/remove digits to the flapper on the fly. So I've modified the original code to allow for adding/removing digits.

Notable Changes:
- existing flappers are stored in a `flappers` object
- ids are added to flapper elements (so that the existing flapper object can be recovered).
- the `.flapper()` jQuery method now supports passing in a string or an object. (so that the specified action will be performed)
- the following methods were added to the prototype: `addDigit`, `removeDigit`, `performAction`

Let me know what you think!