### PR TITLE
Handling word rotation for 1 width flapper.

### DIFF
--- a/src/jquery.flapper.js
+++ b/src/jquery.flapper.js
@@ -86,6 +86,10 @@
         },
 
         getDigits: function(val, length) {
+            if(this.options.width === 1 && val.length  > 1){
+                return [ val + '' ];
+            }
+            
             var strval = val + '';
 
             if (this.options.format) {


### PR DESCRIPTION
If the 'chars' option is set on words, the rotation shows the words. However, only the first character is shown.
Returning the words as an array in the function getDigits fix the issue.